### PR TITLE
[AE-33] injected getProductImages API to APIGateway construct

### DIFF
--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -54,5 +54,10 @@ export class ApiStack extends Stack {
     });
 
     productImageResource.addMethod(POST_LABEL, lambdaIntegration);
+    productImageResource.addMethod(GET_LABEL, lambdaIntegration, {
+        requestParameters: {
+          [PRODUCT_ID_PARAM] : true
+        }
+    });
   }
 }


### PR DESCRIPTION
- Injected getProductImages API to APIGateway resources
- Query parameters contain productId (that is partition key of ProductImage DynamoDb table)