### PR TITLE
[NO-TICKET] add product id to query params of deleteProductImage api

### DIFF
--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -64,7 +64,8 @@ export class ApiStack extends Stack {
     });
     productImageResource.addMethod(DELETE_LABEL, lambdaIntegration, {
       requestParameters: {
-        [ID_PARAM] : true
+        [ID_PARAM] : true,
+        [PRODUCT_ID_PARAM]: true
       }
   });
   }


### PR DESCRIPTION
- added productId as DynamoDb also needs a partitionKey value to delete the entry at a lower latency
- one query parameter is added at the trade off of a faster deletion 