### PR TITLE
[AE-37] filter only remove events from ddb stream on bg operations pipe

### DIFF
--- a/lib/bg-operations-stack.ts
+++ b/lib/bg-operations-stack.ts
@@ -37,12 +37,17 @@ export class BgOperationsStack extends Stack {
 
     const ddbStreamArn = props?.productImageTable.tableStreamArn;
     if (ddbStreamArn) {
+      const isRemovePattern = JSON.stringify({ eventName: ["REMOVE"] });
+
       new CfnPipe(this, PIPE_NAME, {
         name: PIPE_NAME,
         roleArn: pipeRole.roleArn,
         sourceParameters: {
           dynamoDbStreamParameters: {
             startingPosition: "TRIM_HORIZON"
+          },
+          filterCriteria: {
+            filters: [{ pattern: isRemovePattern }]
           },
         },
         source: ddbStreamArn,

--- a/test/bg-operations-stack.test.ts
+++ b/test/bg-operations-stack.test.ts
@@ -44,12 +44,18 @@ test('Bg Operations Resources Created', () => {
     }
   });
 
+  const isRemovePattern = JSON.stringify({ eventName: ["REMOVE"] });
   template.hasResourceProperties('AWS::Pipes::Pipe', {
     Name: PIPE_NAME,
     SourceParameters: {
       DynamoDBStreamParameters: {
         StartingPosition: "TRIM_HORIZON"
-      }
+      },
+      Filters: [
+        {
+          Pattern: isRemovePattern
+        }
+      ]
     }
   });
 });


### PR DESCRIPTION
- filter only remove events so we can clean up s3 bucket on product image deletion
- modify unit test to capture even pattern